### PR TITLE
change color-alpha span height to 100%

### DIFF
--- a/src/wp-color-picker-alpha.js
+++ b/src/wp-color-picker-alpha.js
@@ -200,7 +200,7 @@
 
 						self.toggler.find( 'span.color-alpha' ).css( {
 							'width'                     : '30px',
-							'height'                    : '24px',
+							'height'                    : '100%',
 							'position'                  : 'absolute',
 							'top'                       : 0,
 							'left'                      : 0,


### PR DESCRIPTION
In WordPress 5.2, the height of 24px works, but it needs to be 26px in WordPress 5.3. Changing to 100% fixes for both.

fixes #31