### PR TITLE
Add ability to skip debounce

### DIFF
--- a/src/wp-color-picker-alpha.js
+++ b/src/wp-color-picker-alpha.js
@@ -110,6 +110,7 @@
 				alphaReset: false,
 				alphaColorType: 'hex',
 				alphaColorWithSpace: false,
+				alphaSkipDebounce: false,
 			} );
 
 			this._super();
@@ -146,7 +147,11 @@
 					}
 				};
 
-			input.on( 'change', callback ).on( 'keyup', self._debounce( callback, debounceTimeout ) );
+			input.on( 'change', callback );
+
+			if( ! self.alphaOptions.alphaSkipDebounce ) {
+				input.on( 'keyup', self._debounce( callback, debounceTimeout ) );
+			}
 
 			// If we initialized hidden, show on first focus. The rest is up to you.
 			if ( self.options.hide ) {
@@ -408,6 +413,7 @@
 					alphaReset: false,
 					alphaColorType: 'rgb',
 					alphaColorWithSpace: false,
+					alphaSkipDebounce: ( !!el.data( 'alphaSkipDebounce' ) || false ),
 				};
 
 			if ( options.alphaEnabled ) {


### PR DESCRIPTION

**Problem :**

Debouncing the input after 100ms auto-completes the input, particularly from a short-hand hex input. 

Example, typing `#390` will auto-complete to `#339900` after 100ms. Also attempting to correct the auto-completed input will result in another debounce and auto-completion (see video).

https://github.com/kallookoo/wp-color-picker-alpha/assets/62450648/5c796f2f-b1c7-4ff9-8f57-d07fde993045


**Fix :**

Would like to add the ability to disable debouncing the input through option setting of `data-alpha-skip-debounce`. 