### PR TITLE
Update wp-color-picker-alpha.js

### DIFF
--- a/src/wp-color-picker-alpha.js
+++ b/src/wp-color-picker-alpha.js
@@ -16,11 +16,8 @@
 	};
 
 	// Always try to use the last version of this script.
-	if ( 'wpColorPickerAlpha' in window && 'version' in window.wpColorPickerAlpha ) {
-		var version = parseInt( window.wpColorPickerAlpha.version, 10 );
-		if ( !isNaN( version ) && version >= wpColorPickerAlpha.version ) {
-			return;
-		}
+	if ( window.wpColorPickerAlpha && window.wpColorPickerAlpha.version && window.wpColorPickerAlpha.version >= wpColorPickerAlpha.version ) {
+		return;
 	}
 
 	// Prevent multiple initiations


### PR DESCRIPTION
Instead of parsing the version and comparing integers, you could directly compare the version strings. Also, consider what happens if window.wpColorPickerAlpha.version is not defined, which would cause an error.